### PR TITLE
fix: fx link no longer available

### DIFF
--- a/metadata-exploration/README.md
+++ b/metadata-exploration/README.md
@@ -8,7 +8,6 @@ The metadata information is provided in JSON format. There are various ways to p
 
 * [jq - a lightweight and flexible command line JSON processor](https://stedolan.github.io/jq/)
 * [gron - making JSON greppable](https://github.com/tomnomnom/gron)
-* [fx - function execution](https://github.com/antonmedv/fx)
 * [jless — a command-line JSON viewer](https://jless.io/)
 
 ## Exploration examples


### PR DESCRIPTION
Removing link to no longer existing site on GitHub ( https://github.com/antonmedv/fx )