### PR TITLE
chore: deactivate regular sync run

### DIFF
--- a/.github/workflows/import-metadata.yml
+++ b/.github/workflows/import-metadata.yml
@@ -2,8 +2,8 @@ name: Update Metadata Files
 # Update the metadata information
 
 on:
-  schedule:
-   - cron: "0 6 * * *"
+  #schedule:
+  # - cron: "0 6 * * *"
   workflow_dispatch: {}
   
 jobs:


### PR DESCRIPTION
Deactivate sync run of import until the internal restructuring is finished to avoid unnecessary errors