### PR TITLE
fix: remove obsolete lychee cmd arg

### DIFF
--- a/.github/workflows/link-watcher.yml
+++ b/.github/workflows/link-watcher.yml
@@ -20,6 +20,6 @@ jobs:
         uses: lycheeverse/lychee-action@v2.5.0
         with:
           fail: true
-          args: --verbose --no-progress --exclude-mail --exclude-loopback .
+          args: --verbose --no-progress --exclude-loopback .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Remove obsolte parameter `--exclude-mail` from call
